### PR TITLE
Copy uploaded builds with timestamp to archive

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -159,9 +159,13 @@ echo
 echo "== Transferring artifacts =="
 
 # transfer artifacts to ImageJ download server
+# and copy them to the archive
+timestamp=`date "+%Y%m%d-%H%M"`
 for f in fiji*.zip fiji*.tar.gz
 do
   echo "Uploading $f"
   scp -p "$f" fiji-builds@downloads.imagej.net:"$f.part" &&
   ssh fiji-builds@downloads.imagej.net "mv -f \"$f.part\" \"latest/$f\""
+  ssh fiji-builds@downloads.imagej.net "mkdir -p \"archive/$timestamp\""
+  ssh fiji-builds@downloads.imagej.net "cp \"latest/$f\" \"archive/$timestamp/$f\""
 done


### PR DESCRIPTION
Related to https://github.com/fiji/fiji/issues/223

This PR copies the uploaded files from `latest` to `archive/TIMESTAMP`. `TIMESTAMP` is something like `20190820-1344`. 

The goal is to save future builds with a timestamp in https://downloads.imagej.net/fiji/archive/.

Warning: I only tested this locally without ssh.