### PR TITLE
Add Flatpak support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 
 on:
   push:
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
@@ -19,3 +20,24 @@ jobs:
         env:
            WEBDAV_PASS: ${{ secrets.WEBDAV_PASS }}
            WEBDAV_USER: ${{ secrets.WEBDAV_USER }}
+
+  build-flatpak:
+    name: Build (Flatpak)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cd flatpak/ && podman build -t flatpak -f ./Dockerfile .
+
+    - name: Build
+      run: podman run -t --privileged -v `pwd`:/build flatpak
+           eatmydata ./flatpak/autobuild-bundle.sh
+
+    - name: Upload bundle
+      uses: actions/upload-artifact@v2
+      with:
+        name: Flatpak Bundle
+        path: |
+          flatpak/*.flatpak

--- a/flatpak/.gitignore
+++ b/flatpak/.gitignore
@@ -1,0 +1,4 @@
+.flatpak-builder/
+build-dir/
+tmp_repo/
+*.flatpak

--- a/flatpak/Dockerfile
+++ b/flatpak/Dockerfile
@@ -1,0 +1,21 @@
+#
+# Docker file for building Flatpak bundles
+#
+FROM debian:testing
+
+# prepare
+RUN apt-get update -qq
+RUN apt-get install -yq eatmydata
+
+# install
+RUN DEBIAN_FRONTEND=noninteractive eatmydata apt-get install -yq \
+    ca-certificates \
+    build-essential \
+    git \
+    flatpak \
+    flatpak-builder
+RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+# finish
+RUN mkdir /build
+WORKDIR /build

--- a/flatpak/Dockerfile
+++ b/flatpak/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Docker file for building Flatpak bundles
 #
-FROM debian:testing
+FROM debian:bookworm
 
 # prepare
 RUN apt-get update -qq

--- a/flatpak/autobuild-bundle.sh
+++ b/flatpak/autobuild-bundle.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+cd $(dirname "$0")
+
+build_shell=""
+if [ ! -z "$1" ]
+then
+	echo "Interactive shell at step: $1"
+	build_shell="--build-shell=$1"
+fi
+set -x
+
+flatpak-builder -y \
+	--install-deps-from=flathub \
+	--force-clean \
+	--repo=tmp_repo \
+	$build_shell \
+	build-dir \
+	sc.fiji.fiji.yaml
+
+rm -rf Fiji.flatpak
+flatpak build-bundle \
+	--runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+	tmp_repo/ \
+	Fiji.flatpak \
+	sc.fiji.fiji
+
+rm -r tmp_repo/

--- a/flatpak/launch-fiji.sh
+++ b/flatpak/launch-fiji.sh
@@ -5,9 +5,9 @@ tmpl_dir="/app/fiji"
 mut_userdir="/var/data"
 
 if [ ! -f "$mut_userdir/ImageJ-linux64" ]; then
-  echo "Copying ImageJ to mutable, user-owned directory..."
+  echo "Copying Fiji to mutable, user-owned directory..."
   cp -dr --preserve=mode $tmpl_dir/* $mut_userdir/
-  rm $mut_userdir/launch-imagej.sh
+  rm $mut_userdir/launch-fiji.sh
 fi
 
 exec $mut_userdir/ImageJ-linux64 --system $@

--- a/flatpak/launch-imagej.sh
+++ b/flatpak/launch-imagej.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+tmpl_dir="/app/fiji"
+mut_userdir="/var/data"
+
+if [ ! -f "$mut_userdir/ImageJ-linux64" ]; then
+  echo "Copying ImageJ to mutable, user-owned directory..."
+  cp -dr --preserve=mode $tmpl_dir/* $mut_userdir/
+  rm $mut_userdir/launch-imagej.sh
+fi
+
+exec $mut_userdir/ImageJ-linux64 --system $@

--- a/flatpak/patches/ijlauncher_Consider-files-with-an-mtime-of-0.patch
+++ b/flatpak/patches/ijlauncher_Consider-files-with-an-mtime-of-0.patch
@@ -1,0 +1,27 @@
+From e92c91b6b45d228164c960414edb5fb84b35b584 Mon Sep 17 00:00:00 2001
+From: Matthias Klumpp <matthias@tenstral.net>
+Date: Fri, 11 Mar 2022 19:09:38 +0100
+Subject: [PATCH] Consider files with an mtime of 0 as well
+
+Somehow the mtimes of the files are all at 0 in Flatpak, which trips up
+imagej-launcher and makes it refuse to launch anything.
+---
+ src/main/c/file-funcs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/main/c/file-funcs.c b/src/main/c/file-funcs.c
+index 56340a0..3cc4a2a 100644
+--- a/src/main/c/file-funcs.c
++++ b/src/main/c/file-funcs.c
+@@ -399,7 +399,7 @@ char *find_jar(const char *jars_directory, const char *prefix)
+ 			continue;
+ 		string_set_length(buffer, length);
+ 		string_append(buffer, name);
+-		if (!stat(buffer->buffer, &st) && st.st_mtime > mtime) {
++		if (!stat(buffer->buffer, &st) && st.st_mtime >= mtime) {
+ 			free(result);
+ 			result = strdup(buffer->buffer);
+ 			mtime = st.st_mtime;
+-- 
+2.35.1
+

--- a/flatpak/sc.fiji.fiji.desktop
+++ b/flatpak/sc.fiji.fiji.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+
+Name=Fiji (Is Just ImageJ)
+GenericName=Fiji
+Comment=Scientific Image Analysis
+Icon=sc.fiji.fiji
+
+Categories=Education;Science;ImageProcessing;
+Exec=/app/fiji/launch-imagej.sh %F
+
+Terminal=false
+StartupNotify=true
+StartupWMClass=net-imagej-launcher-ClassLauncher
+MimeType=image/*;

--- a/flatpak/sc.fiji.fiji.desktop
+++ b/flatpak/sc.fiji.fiji.desktop
@@ -8,7 +8,7 @@ Comment=Scientific Image Analysis
 Icon=sc.fiji.fiji
 
 Categories=Education;Science;ImageProcessing;
-Exec=/app/fiji/launch-imagej.sh %F
+Exec=/app/fiji/launch-fiji.sh %F
 
 Terminal=false
 StartupNotify=true

--- a/flatpak/sc.fiji.fiji.metainfo.xml
+++ b/flatpak/sc.fiji.fiji.metainfo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>sc.fiji.fiji</id>
+
+  <name>Fiji</name>
+  <summary>Scientific image analysis with ImageJ</summary>
+
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>LicenseRef-free=https://imagej.net/licensing/</project_license>
+
+  <description>
+    <p>
+      Fiji is an image processing package — a "batteries-included" distribution of ImageJ,
+      bundling many plugins which facilitate scientific image analysis.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">sc.fiji.fiji.desktop</launchable>
+</component>

--- a/flatpak/sc.fiji.fiji.metainfo.xml
+++ b/flatpak/sc.fiji.fiji.metainfo.xml
@@ -16,4 +16,8 @@
   </description>
 
   <launchable type="desktop-id">sc.fiji.fiji.desktop</launchable>
+
+  <releases>
+    <release version="2.14.0" date="2023-09-19"/>
+  </releases>
 </component>

--- a/flatpak/sc.fiji.fiji.yaml
+++ b/flatpak/sc.fiji.fiji.yaml
@@ -1,0 +1,87 @@
+id: sc.fiji.fiji
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk8
+command: /app/fiji/launch-imagej.sh
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=host
+  - --env=PATH=/app/bin:/app/jre/bin:/usr/bin
+  - --env=JAVA_HOME=/app/jre
+
+build-options:
+  env:
+    PATH: /app/bin:/usr/bin:/usr/lib/sdk/openjdk8/bin/
+    JAVA_HOME: /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/
+  build-args:
+    - --share=network
+
+modules:
+- name: openjdk
+  buildsystem: simple
+  build-commands:
+    - /usr/lib/sdk/openjdk8/install.sh
+
+- name: imagej-launcher
+  buildsystem: simple
+  build-commands:
+    - cmake -GNinja -Bb -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+    - cd b && ninja
+    - mkdir -p /app/fiji/
+    - install b/ImageJ-linux64 /app/fiji/
+  sources:
+    - type: git
+      tag: imagej-launcher-6.0.2
+      url: https://github.com/imagej/imagej-launcher.git
+    - type: patch
+      path: patches/ijlauncher_Consider-files-with-an-mtime-of-0.patch
+
+- name: fiji-make
+  buildsystem: simple
+  build-commands:
+    - mvn clean install -DskipTests -Dscijava.app.directory="/app/fiji"
+  sources:
+    - type: git
+      url: https://github.com/fiji/fiji.git
+
+- name: fiji-update
+  buildsystem: simple
+  build-options:
+    env:
+      DEBUG: '1'
+  build-commands:
+    - /app/fiji/ImageJ-linux64 --update add-update-site Fiji https://update.fiji.sc/
+    - /app/fiji/ImageJ-linux64 --update add-update-site Java-8 https://sites.imagej.net/Java-8/
+    - /app/fiji/ImageJ-linux64 --update update-force-pristine
+    # restore our patched launcher
+    - rm /app/fiji/ImageJ-linux64
+    - mv /app/fiji/ImageJ-linux64.old /app/fiji/ImageJ-linux64
+
+- name: fiji-cleanup
+  buildsystem: simple
+  build-commands:
+    - rm -rf /app/fiji/jars/linux32 /app/fiji/jars/macosx /app/fiji/jars/win32 /app/fiji/jars/win64
+    # make sure the launcher doesn't create an additional, bad desktop-entry file
+    - touch /app/fiji/ImageJ2.desktop /app/fiji/Fiji.desktop /app/fiji/ImageJ.desktop
+
+- name: fiji-metadata
+  buildsystem: simple
+  build-commands:
+    - install -D sc.fiji.fiji.metainfo.xml /app/share/metainfo/sc.fiji.fiji.metainfo.xml
+    - install -D /app/fiji/images/icon.png /app/share/icons/hicolor/256x256/apps/sc.fiji.fiji.png
+    - install -D sc.fiji.fiji.desktop /app/share/applications/sc.fiji.fiji.desktop
+    - install -D launch-imagej.sh /app/fiji/launch-imagej.sh
+  sources:
+    - type: file
+      path: sc.fiji.fiji.metainfo.xml
+    - type: file
+      path: sc.fiji.fiji.desktop
+    - type: file
+      path: launch-imagej.sh

--- a/flatpak/sc.fiji.fiji.yaml
+++ b/flatpak/sc.fiji.fiji.yaml
@@ -1,10 +1,10 @@
 id: sc.fiji.fiji
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk8
-command: /app/fiji/launch-imagej.sh
+command: /app/fiji/launch-fiji.sh
 
 finish-args:
   - --share=ipc
@@ -49,13 +49,14 @@ modules:
     - mvn clean install -DskipTests -Dscijava.app.directory="/app/fiji"
   sources:
     - type: git
+      # TODO: pin to a specific commit for reproducible builds
+      branch: main
       url: https://github.com/fiji/fiji.git
 
 - name: fiji-update
   buildsystem: simple
-  build-options:
-    env:
-      DEBUG: '1'
+  # Network access is required here: Fiji's updater fetches plugins and the
+  # Java-8 JRE from the official update sites as part of the build.
   build-commands:
     - /app/fiji/ImageJ-linux64 --update add-update-site Fiji https://update.fiji.sc/
     - /app/fiji/ImageJ-linux64 --update add-update-site Java-8 https://sites.imagej.net/Java-8/
@@ -77,11 +78,11 @@ modules:
     - install -D sc.fiji.fiji.metainfo.xml /app/share/metainfo/sc.fiji.fiji.metainfo.xml
     - install -D /app/fiji/images/icon.png /app/share/icons/hicolor/256x256/apps/sc.fiji.fiji.png
     - install -D sc.fiji.fiji.desktop /app/share/applications/sc.fiji.fiji.desktop
-    - install -D launch-imagej.sh /app/fiji/launch-imagej.sh
+    - install -D launch-fiji.sh /app/fiji/launch-fiji.sh
   sources:
     - type: file
       path: sc.fiji.fiji.metainfo.xml
     - type: file
       path: sc.fiji.fiji.desktop
     - type: file
-      path: launch-imagej.sh
+      path: launch-fiji.sh


### PR DESCRIPTION
Hi!
I saw your request for a Debian packager on https://imagej.net/software/fiji/downloads - since I am one, I decided to give this a go, but then  ultimately ended up creating a Flatpak bundle for Fiji instead, which I think users may be a bit happier with :-)
[Flatpak](https://flatpak.org/) is a widely supported bundling system on Linux, which makes it possible to "freeze" and app with its dependencies, to deploy it easily to pretty much any Linux distribution.
It's a pretty convenient and widely available way to make software available on Linux nowadays.

I created this recipe so we could use Fiji easily on our more powerful shared servers where people connect to from remote locations (and where having every user download Fiji manually is pretty inconvenient, compared to just selecting it from the menu and it just working).

There is one huge issue with Fiji in a Flatpak currently though: Flatpak apps are run from a read-only filesystem by design, while ImageJ/Fiji was written to modify its own files at runtime with its own updater. Originally I just intended to remove the updater and use Flatpak's own very efficient update mechanism to automatically keep Fiji up-to-date.
Unfortunately, removing the updater also cuts off any way for users to easily install ImageJ plugins, which is not an acceptable compromise.
So, what this bundle will do instead is copy the entire Fiji distribution into the user's writable data location and then run it from there. It still runs in the isolated Flatpak environment, but Fiji can modify itself now. Of course this is bad design, as it duplicates data for every user who runs Fiji on the machine, is less secure, and if the home directory is on a filesystem that prevents executables, it won't work either.
Ideally, ImageJ/Fiji would be modified to allow loading modules from separate writable paths and to split the externally-managed plugins from the ones Fiji ships with, so one half can be on a read-only filesystem, while users can still add their own plugin sources. But that would require quite a few changes on the existing codebase, so for now the Flatpak bundle uses the copy-everything compromise.

Another pretty evil thing is that network access is enabled during build, but the advantage of that is that the Flatpak bundle can be created very easily using the same process as all the other binary distributions are using.

**If you just want a Fiji Flatpak build that you can use on your machine, download a test-build from here: https://github.com/ximion/fiji-builds/releases/tag/x-test**

So, how can you create the build yourself?
#### 1. Install Flatpak
```bash
sudo apt install flatpak flatpak-builder
sudo systemctl reboot # restarts the computer
```
#### 2. Configure Flatpak to use Flathub for SDKs/Runtimes
```bash
sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
```
#### 3. Build the bundle
```bash
cd flatpak/
./autobuild-bundle.sh
```

#### 4. Install the application!
You can open the resulting `Fiji.flatpak` in KDE Discover or GNOME Software for a GUI to install it, or install it via the command-line:
```bash
flatpak install ./Fiji.flatpak
```
You can then just launch Fiji by clicking its icon on the menu!

I included changes to the GitHub action with this PR, which makes it build the Flatpak bundle in a separate job and uploads it as an artifact, so you can fetch it from there for testing purposes.
I deliberately didn't touch the code that uploads directly to the Fiji download site.
This PR will address Fiji issue https://github.com/fiji/fiji/issues/287
Thanks for considering! :-)
Cheers,
    Matthias